### PR TITLE
fail_timeout=0

### DIFF
--- a/files/default/template.ctmpl
+++ b/files/default/template.ctmpl
@@ -1,5 +1,5 @@
 upstream REPLACEME {
-  {{range service "REPLACEME"}}server {{ .Address }}:{{ .Port }};
+  {{range service "REPLACEME"}}server {{ .Address }}:{{ .Port }} fail_timeout=0;
   {{else}}server 127.0.0.1:404;
   {{end}}
 }

--- a/files/default/templateSSL.ctmpl
+++ b/files/default/templateSSL.ctmpl
@@ -1,5 +1,5 @@
 upstream REPLACEME {
-  {{range service "REPLACEME"}}server {{ .Address }}:{{ .Port }};
+  {{range service "REPLACEME"}}server {{ .Address }}:{{ .Port }} fail_timeout=0;
   {{else}}server 127.0.0.1:404;
   {{end}}
 }


### PR DESCRIPTION
simply added fail_timeout=0 to the upstream stanzas in the template.ctmpl and templateSSL.ctmpl files, this is in reference to https://github.com/octohost/octohost/issues/119
